### PR TITLE
Bump GraphQL-ruby to 0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,7 @@
 source 'https://rubygems.org'
 
 ruby '2.2.2'
-gem 'graphql',
-  '0.3.0'
-  # path: "~/projects/graphql"
+gem 'graphql', '0.5.0'
 gem 'skyblue_rails'
 gem 'react-rails'
 gem 'rails_12factor', group: :production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     execjs (2.5.2)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
-    graphql (0.3.0)
+    graphql (0.5.0)
       parslet (~> 1.6)
     i18n (0.7.0)
     jquery-rails (4.0.4)
@@ -156,7 +156,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   byebug
-  graphql (= 0.3.0)
+  graphql (= 0.5.0)
   jquery-rails
   pg
   rails (= 4.2.2)
@@ -169,4 +169,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/app/graph/fields/fetch_field.rb
+++ b/app/graph/fields/fetch_field.rb
@@ -4,7 +4,7 @@ class FetchField < GraphQL::Field
     @model = model
     self.description = "Find a #{model.name} by ID"
     self.arguments = {
-      id: GraphQL::InputValue.new(type: !GraphQL::INT_TYPE, description: "Id for record", default_value: nil)
+      id: GraphQL::Argument.new(type: !GraphQL::INT_TYPE, description: "Id for record", default_value: nil)
     }
   end
 

--- a/app/graph/types/character_interface.rb
+++ b/app/graph/types/character_interface.rb
@@ -4,13 +4,11 @@
 #   friends: [Character]
 #   appearsIn: [Episode]
 # }
-CharacterInterface = GraphQL::InterfaceType.new do |i, type, field|
-  i.name "Character"
-  i.description "A sentient actor in Star Wars"
-  i.fields({
-    id:         field.build(type: !type.Int, desc: "The unique ID of this person"),
-    name:       field.build(type: !type.String, desc: "The name of this person"),
-    friends:    field.build(type: type[i], desc: "Friends of this person"),
-    appearsIn:  field.build(type: type[EpisodeEnum], property: :appears_in_names, desc: "Episodes this person appears in"),
-  })
+CharacterInterface = GraphQL::InterfaceType.define do
+  name "Character"
+  description "A sentient actor in Star Wars"
+  field :id,        !types.Int, "The unique ID of this person"
+  field :name,      !types.String, "The name of this person"
+  field :friends,   -> { types[CharacterInterface] }, "Friends of this person"
+  field :appearsIn, types[EpisodeEnum], "Episodes this person appears in", property: :appears_in_names
 end

--- a/app/graph/types/character_interface.rb
+++ b/app/graph/types/character_interface.rb
@@ -4,7 +4,7 @@
 #   friends: [Character]
 #   appearsIn: [Episode]
 # }
-CharacterInterface = GraphQL::Interface.new do |i, type, field|
+CharacterInterface = GraphQL::InterfaceType.new do |i, type, field|
   i.name "Character"
   i.description "A sentient actor in Star Wars"
   i.fields({

--- a/app/graph/types/droid_type.rb
+++ b/app/graph/types/droid_type.rb
@@ -5,15 +5,14 @@
 #   appearsIn: [Episode]
 #   primaryFunction: String
 # }
-DroidType = GraphQL::ObjectType.new do |t, type, field|
-  t.name "Droid"
-  t.description "A robotic character in Star Wars"
-  t.fields({
-    id:               field.build(type: !type.Int, desc: "The unique ID of this droid"),
-    name:             field.build(type: !type.String, desc: "The name of this droid"),
-    friends:          field.build(type: type[CharacterInterface], desc: "Friends of this droid"),
-    appearsIn:        field.build(type: type[EpisodeEnum], desc: "Episodes this droid appears in"),
-    primaryFunction:  field.build(type: type.String, property: :primary_function, desc: "What this droid is for"),
-  })
-  t.interfaces [CharacterInterface]
+DroidType = GraphQL::ObjectType.define do
+  name "Droid"
+  description "A robotic character in Star Wars"
+  interfaces [CharacterInterface]
+
+  field :id, !types.Int, "The unique ID of this droid"
+  field :name, !types.String, "The name of this droid"
+  field :friends, types[CharacterInterface], "Friends of this droid"
+  field :appearsIn, types[EpisodeEnum], "Episodes this droid appears in"
+  field :primaryFunction,  types.String, "What this droid is for", property: :primary_function
 end

--- a/app/graph/types/episode_enum.rb
+++ b/app/graph/types/episode_enum.rb
@@ -1,5 +1,5 @@
 # enum Episode { NEWHOPE, EMPIRE, JEDI }
-EpisodeEnum = GraphQL::Enum.new do |e|
+EpisodeEnum = GraphQL::EnumType.new do |e|
   e.name "Episode"
   e.description "An part of the Star Wars saga"
   e.value("NEWHOPE",  "Part 4", value: 4)

--- a/app/graph/types/episode_enum.rb
+++ b/app/graph/types/episode_enum.rb
@@ -1,8 +1,8 @@
 # enum Episode { NEWHOPE, EMPIRE, JEDI }
-EpisodeEnum = GraphQL::EnumType.new do |e|
-  e.name "Episode"
-  e.description "An part of the Star Wars saga"
-  e.value("NEWHOPE",  "Part 4", value: 4)
-  e.value("EMPIRE",   "Part 5", value: 5)
-  e.value("JEDI",     "Part 6", value: 6)
+EpisodeEnum = GraphQL::EnumType.define do
+  name "Episode"
+  description "An part of the Star Wars saga"
+  value("NEWHOPE",  "Part 4", value: 4)
+  value("EMPIRE",   "Part 5", value: 5)
+  value("JEDI",     "Part 6", value: 6)
 end

--- a/app/graph/types/human_type.rb
+++ b/app/graph/types/human_type.rb
@@ -5,15 +5,14 @@
 #   appearsIn: [Episode]
 #   homePlanet: String
 # }
-HumanType = GraphQL::ObjectType.new do |t, types, field|
-  t.name "Human"
-  t.description "A flesh-and-blood character in Star Wars"
-  t.fields({
-    id:         field.build(type: !types.Int, desc: "The unique ID of this person"),
-    name:       field.build(type: !types.String, desc: "The name of this person"),
-    friends:    field.build(type: types[CharacterInterface], desc: "Friends of this person"),
-    appearsIn:  field.build(type: types[EpisodeEnum], desc: "Episodes this person appears in"),
-    homePlanet: field.build(type: types.String, property: :home_planet, desc: "Where this person is from"),
-  })
-  t.interfaces [CharacterInterface]
+HumanType = GraphQL::ObjectType.define do
+  name "Human"
+  description "A flesh-and-blood character in Star Wars"
+  interfaces [CharacterInterface]
+
+  field :id, !types.Int, "The unique ID of this person"
+  field :name, !types.String, "The name of this person"
+  field :friends, types[CharacterInterface], "Friends of this person"
+  field :appearsIn, types[EpisodeEnum], "Episodes this person appears in"
+  field :homePlanet, types.String, "Where this person is from", property: :home_planet
 end

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -3,25 +3,22 @@
 #   human(id: String!): Human
 #   droid(id: String!): Droid
 # }
-QueryType = GraphQL::ObjectType.new do |t|
-  t.name "Query"
-  t.description "The query root for this schema"
-  t.fields({
-    # You can define fields on the fly:
-    hero: GraphQL::Field.new { |f, types, field, arg|
-      f.description("The hero of the saga")
-      f.type(!CharacterInterface)
-      f.arguments(episode: arg.build(
-        type: EpisodeEnum,
-        desc: "If provided, return the hero of that episode"
-        )
-      )
-      f.resolve -> (o, a, c) {
-        a["episode"] == 5 ? Human.find(1000) : Droid.find(2001)
-      }
-    },
-    # Or use hand-rolled fields:
-    human: FetchField.new(type: HumanType, model: Human),
-    droid: FetchField.new(type: DroidType, model: Droid),
-  })
+QueryType = GraphQL::ObjectType.define do
+  name "Query"
+  description "The query root for this schema"
+
+  # You can define fields on the fly:
+  field :hero do
+    type -> { !CharacterInterface }
+    description "The hero of the saga"
+
+    argument :episode, EpisodeEnum, "If provided, return the hero of that episode"
+
+    resolve -> (obj, args, ctx) do
+      args["episode"] == 5 ? Human.find(1000) : Droid.find(2001)
+    end
+  end
+
+  field :human, HumanType, field: FetchField.new(type: HumanType, model: Human)
+  field :droid, DroidType, field: FetchField.new(type: DroidType, model: Droid)
 end


### PR DESCRIPTION
I was messing around a bit and got confused by this mismatch, so here's a bump to the GraphQL-ruby version that fixes some references to names that no longer exist in 0.5.0.
