### PR TITLE
Adds build status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/rmosolgo/graphql-ruby-demo.svg?branch=master)](https://travis-ci.org/rmosolgo/graphql-ruby-demo)
+
 ## graphql-ruby-demo
 Shows an implementation of GraphQL via [graphql-ruby](https://github.com/rmosolgo/graphql-ruby).
 


### PR DESCRIPTION
Generated on https://travis-ci.org/rmosolgo/graphql-ruby-demo (click the build status, then select `MARKDOWN`).
